### PR TITLE
Update to .NET 9.0 and package references

### DIFF
--- a/BlazorApp4/BlazorApp4.Client/BlazorApp4.Client.csproj
+++ b/BlazorApp4/BlazorApp4.Client/BlazorApp4.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/BlazorApp4/BlazorApp4/BlazorApp4.csproj
+++ b/BlazorApp4/BlazorApp4/BlazorApp4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-BlazorApp4-ef2a0434-c1e7-44b1-89a9-cf59e6aaca61</UserSecretsId>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BlazorApp4.Client\BlazorApp4.Client.csproj" />
     <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated the target framework for both Blazor client and server projects from .NET 8.0 to .NET 9.0. Updated package references in the Blazor client project to version 9.0.0 for:
- Microsoft.AspNetCore.Components.WebAssembly
- Microsoft.AspNetCore.Components.WebAssembly.Authentication
- Microsoft.Extensions.Http

Updated the Blazor server project package reference to version 9.0.0 for:
- Microsoft.AspNetCore.Components.WebAssembly.Server