### PR TITLE
Update NuGet package versions to 9.0.1

### DIFF
--- a/BlazorApp4/BlazorApp4.Client/BlazorApp4.Client.csproj
+++ b/BlazorApp4/BlazorApp4.Client/BlazorApp4.Client.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/BlazorApp4/BlazorApp4.Client/UserInfo.cs
+++ b/BlazorApp4/BlazorApp4.Client/UserInfo.cs
@@ -1,8 +1,6 @@
-namespace BlazorApp4.Client
+namespace BlazorApp4.Client;
+public class UserInfo
 {
-    public class UserInfo
-    {
-        public required string UserId { get; set; }
-        public required string Email { get; set; }
-    }
+    public required string UserId { get; set; }
+    public required string Email { get; set; }
 }

--- a/BlazorApp4/BlazorApp4/AuthenticationExtensions.cs
+++ b/BlazorApp4/BlazorApp4/AuthenticationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Auth0.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+
 namespace BlazorApp4;
 
 public static class AuthenticationExtensions

--- a/BlazorApp4/BlazorApp4/BlazorApp4.csproj
+++ b/BlazorApp4/BlazorApp4/BlazorApp4.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BlazorApp4.Client\BlazorApp4.Client.csproj" />
     <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/BlazorApp4/BlazorApp4/Program.cs
+++ b/BlazorApp4/BlazorApp4/Program.cs
@@ -4,20 +4,21 @@ using BlazorApp4.Client;
 using BlazorApp4.Client.Pages;
 using BlazorApp4.Client.Services;
 using BlazorApp4.Components;
-using BlazorApp4.Identity;
 using BlazorApp4.Services;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Components.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
+    .AddAuthenticationStateSerialization()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
 
 builder.Services.AddCascadingAuthenticationState();
-builder.Services.AddScoped<AuthenticationStateProvider, PersistingRevalidatingAuthenticationStateProvider>();
+
+//replaced by built in  .AddAuthenticationStateSerialization()
+//builder.Services.AddScoped<AuthenticationStateProvider, PersistingRevalidatingAuthenticationStateProvider>();
 
 builder.Services.AddAuth0WebAppAuthentication(options =>
 {

--- a/BlazorApp4/BlazorApp4/Services/BaseUrlProvider.cs
+++ b/BlazorApp4/BlazorApp4/Services/BaseUrlProvider.cs
@@ -2,7 +2,7 @@
 
 public class BaseUrlProvider
 {
-    public string BaseUrl { get; private set; }
+    public string? BaseUrl { get; private set; }
 
     public void SetBaseUrl(string baseUrl)
     {


### PR DESCRIPTION
Updated several NuGet package references in the
`BlazorApp4.Client.csproj` and `BlazorApp4.csproj` files from version 9.0.0 to 9.0.1, including:
- `Microsoft.AspNetCore.Components.WebAssembly`
- `Microsoft.AspNetCore.Components.WebAssembly.Authentication`
- `Microsoft.Extensions.Http`
- `Microsoft.AspNetCore.Components.WebAssembly.Server` The `Auth0.AspNetCore.Authentication` package remains at version 1.4.1.